### PR TITLE
wfd-commonsys: Guard against non-QSSI_SUPPORTED_PLATFORMS

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,5 +1,7 @@
 LOCAL_PATH := $(call my-dir)
 
+ifneq ($(filter $(QSSI_SUPPORTED_PLATFORMS),$(TARGET_BOARD_PLATFORM)),)
+
 #Disable WFD for selected 32-bit targets
 ifeq ($(call is-board-platform,bengal),true)
 ifeq ($(TARGET_BOARD_SUFFIX),_32)
@@ -18,4 +20,5 @@ ifneq ($(TARGET_HAS_LOW_RAM), true)
 include $(call all-makefiles-under, $(LOCAL_PATH))
 endif
 endif
+
 endif


### PR DESCRIPTION
MTK devices need this commit, otherwise kaleidoscopeOS cannot be built.